### PR TITLE
Fix 'Bare node creation' test of IHACRESExpuhNode

### DIFF
--- a/src/Nodes/IHACRES/IHACRESExpuhNode.jl
+++ b/src/Nodes/IHACRES/IHACRESExpuhNode.jl
@@ -12,7 +12,7 @@ Base.@kwdef mutable struct ExpuhNode{P, A<:AbstractFloat} <: IHACRESNode
     e::P = Param(1.0, bounds=(0.1, 1.5))  # temperature to PET conversion factor
     f::P = Param(0.8, bounds=(0.01, 3.0))  # plant stress threshold factor (multiplicative factor of d)
     tau_q::P = Param(1.0, bounds=(0.0, 5.0))
-    tau_s::P = Param(5, bounds=(5.0, 200.0))
+    tau_s::P = Param(5.0, bounds=(5.0, 200.0))
     v_s::P = Param(0.5, bounds=(0.0, 1.0))
 
     storage_coef::P = Param(2.9, bounds=(0.2, 10.0))

--- a/src/Nodes/IHACRES/IHACRESExpuhNode.jl
+++ b/src/Nodes/IHACRES/IHACRESExpuhNode.jl
@@ -167,7 +167,7 @@ function run_node!(s_node::ExpuhNode,
 
     level::Float64 = @ccall IHACRES.calc_ft_level(outflow::Cdouble, s_node.level_params::Ptr{Cdouble})::Cdouble
 
-    update_state(s_node, cmd, e_rainfall, et, quick_store, slow_store, outflow, level, gw_store)
+    update_state!(s_node, cmd, e_rainfall, et, quick_store, slow_store, outflow, level, gw_store)
 
     return (outflow, level)
 end
@@ -213,7 +213,7 @@ function run_node_with_temp!(s_node::ExpuhNode, rain::Float64, temp::Float64, in
 
     level::Float64 = @ccall IHACRES.calc_ft_level(outflow::Cdouble, s_node.level_params::Ptr{Cdouble})::Cdouble
 
-    update_state(s_node, cmd, e_rainfall, et, quick_store, slow_store, outflow, level, gw_store)
+    update_state!(s_node, cmd, e_rainfall, et, quick_store, slow_store, outflow, level, gw_store)
 
     return (outflow, level)
 end


### PR DESCRIPTION
This PR fixes two errors on the 'Bare node creation' test of IHACRESExpuhNode

1. Running this test was causing the error `MethodError: no method matching unsafe_convert(::Type{Float64}, ::Int64)`. This happened because `tau_s` value was an integer and should be a float. The PR changes the default value of tau_s from 5 to 5.0.
2. Running this test was causing the error `MethodError: no method matching update_state`. This is happening because the commit 775a575 changed the definition of some methods, and not all usage of these methods has changed. The PR changes two calls to `update_state` to `update_state!`.

@ConnectedSystems let me know if this makes sense. I went straight to creating a PR and not an issue because it seemed like a simple change, but let me know if you'd prefer something else.